### PR TITLE
add Chromedriver support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.tags
 /lib-cov/
 /lib/selenium-server-standalone-*.jar
+/lib/chromedriver*
 /node_modules/
 /npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /lib/chromedriver*
 /node_modules/
 /npm-debug.log
+tmp/chrome*
+tmp/selenium*

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "laxcomma": true,
+  "asi": true
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+clean:
+	rm -f tmp/*
+
+.PHONY: clean

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 
 var platform
   , arch = '32'
-  , version = '2.2'
+  , version = '2.6'
 
 switch(process.platform){
   case 'darwin':
@@ -25,14 +25,14 @@ switch(process.platform){
 }
 
 var expectedSha = {
-  'linux32': '9f6bad3a1004cd983731a7b68c0a03f9c6b45696',
-  'linux64': 'c737452bacba963a36d32b3bc0fdb87cb6cb25a6',
-  'mac32': '8328d845afb2e5e124f38a2d72dbfc659c0936b0',
-  'win32': '7723028c78074144065d07566d77a4c2f19c390a'
+  'linux32': '50fa5c13e7e5a16704c1ea6a5951ddb9198c503b',
+  'linux64': 'cab1c61eea5397498f6a095fcbf726772554fb21',
+  'mac32': '4643652d403961dd9a9a1980eb1a06bf8b6e9bad',
+  'win32': '4196e08c591145fc51828e0a3045f35cb142c51f'
 }
 
-var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip'
-  , url = 'https://chromedriver.googlecode.com/files/'+ filename
+var filename = 'chromedriver_'+ platform + arch +'.zip'
+  , url = 'http://chromedriver.storage.googleapis.com/'+ version +'/'+ filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
   , driver = path.join(path.dirname(__filename), '..', 'tmp', 'chromedriver')
 

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -50,20 +50,13 @@ module.exports = function(options, cb){
     return cb('No Chromedriver support for platform: '+ process.platform)
   }
 
-  var real = function() {
+  function download() {
     console.log('Downloading Chromedriver '+ version)
     var i = 0
     request({ url: url })
       .on('end', function() {
         process.stdout.write('\n')
-        process.nextTick(function(){
-          var zip = new Zip(outfile)
-          zip.extractAllTo(path.dirname(__filename))
-          fs.chmod(driver, '0111', function(err){
-            if(err) return cb(err)
-            cb(null, driver)
-          })
-        })
+        extractFile();
       })
       .on('data', function() {
         if (i == 8000) {
@@ -76,11 +69,32 @@ module.exports = function(options, cb){
       .pipe(fs.createWriteStream(outfile))
   }
 
+  var retry = 5;
+
+  function extractFile(){
+    try {
+      var zip = new Zip(outfile)
+      zip.extractAllTo(path.join(path.dirname(__filename), '..', 'tmp'))
+      fs.chmod(driver, '0111', function(err){
+        if(err) return cb(err)
+        cb(null, driver)
+      })
+    } catch(err) {
+      if( --retry ){
+        setTimeout(extractFile, 100);
+      } else {
+        fs.unlink(outfile, function(){
+          throw new Error(err);
+        })
+      }
+    }
+  }
+
   fs.stat(outfile, function(er, stat) {
-    if (er) return real()
+    if (er) return download()
     hashFile(outfile, 'sha1', function(er, actualSha) {
       if (er) return cb(er)
-      if (actualSha != expectedSha[platform + arch]) return real()
+      if (actualSha != expectedSha[platform + arch]) return download()
       cb(null, driver)
     })
   })

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -1,0 +1,89 @@
+var fs = require('fs');
+var path = require('path');
+var request = require('request');
+var hashFile = require('hash_file');
+var Zip = require('adm-zip');
+
+
+var arch = '32';
+var version = '2.2';
+var platform;
+
+switch(process.platform){
+  case 'darwin':
+    platform = 'mac';
+    break;
+  case 'win32':
+    platform = 'win';
+    break;
+  case 'linux':
+    platform = 'linux';
+    arch = process.arch === 'x64' ? '64' : '32';
+    break;
+  default:
+    platform = false;
+    break;
+}
+
+var expectedSha = {
+  'linux32': '9f6bad3a1004cd983731a7b68c0a03f9c6b45696',
+  'linux64': 'c737452bacba963a36d32b3bc0fdb87cb6cb25a6',
+  'mac32': '8328d845afb2e5e124f38a2d72dbfc659c0936b0',
+  'win32': '7723028c78074144065d07566d77a4c2f19c390a'
+};
+
+var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip';
+var url = 'https://chromedriver.googlecode.com/files/'+ filename;
+var outfile = path.join(path.dirname(__filename), filename);
+var driver = path.join(path.dirname(__filename), 'chromedriver');
+
+module.exports = function(options, cb){
+  if( !cb && typeof options === 'function' ){
+    cb = options;
+    options = {};
+  }
+
+  if( !options.chrome ){
+    return cb();
+  }
+
+  if( !platform ){
+    return cb('No Chromedriver support for platform: '+ process.platform);
+  }
+
+  var real = function() {
+    console.log('Downloading Chromedriver '+ version);
+    var i = 0;
+    request({ url: url })
+      .on('end', function() {
+        process.stdout.write('\n');
+        process.nextTick(function(){
+          var zip = new Zip(outfile);
+          zip.extractAllTo(path.dirname(__filename));
+          fs.chmod(driver, '0111', function(err){
+            if(err) return cb(err);
+            cb(null, driver);
+          });
+        })
+      })
+      .on('data', function() {
+        if (i == 8000) {
+          process.stdout.write('\n');
+          i = 0;
+        }
+        if (i % 100 === 0) process.stdout.write('.');
+        i++;
+      })
+      .pipe(fs.createWriteStream(outfile));
+  };
+
+  fs.stat(outfile, function(er, stat) {
+    if (er) return real();
+    hashFile(outfile, 'sha1', function(er, actualSha) {
+      if (er) return cb(er);
+      if (actualSha != expectedSha[platform + arch]) return real();
+      cb(null, driver);
+    });
+  });
+
+};

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -33,8 +33,8 @@ var expectedSha = {
 
 var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip'
   , url = 'https://chromedriver.googlecode.com/files/'+ filename
-  , outfile = path.join(path.dirname(__filename), filename)
-  , driver = path.join(path.dirname(__filename), 'chromedriver')
+  , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
+  , driver = path.join(path.dirname(__filename), '..', 'tmp', 'chromedriver')
 
 module.exports = function(options, cb){
   if( !cb && typeof options === 'function' ){

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -1,28 +1,27 @@
-var fs = require('fs');
-var path = require('path');
-var request = require('request');
-var hashFile = require('hash_file');
-var Zip = require('adm-zip');
+var fs = require('fs')
+  , path = require('path')
+  , request = require('request')
+  , hashFile = require('hash_file')
+  , Zip = require('adm-zip')
 
-
-var arch = '32';
-var version = '2.2';
-var platform;
+var platform
+  , arch = '32'
+  , version = '2.2'
 
 switch(process.platform){
   case 'darwin':
-    platform = 'mac';
-    break;
+    platform = 'mac'
+    break
   case 'win32':
-    platform = 'win';
-    break;
+    platform = 'win'
+    break
   case 'linux':
-    platform = 'linux';
-    arch = process.arch === 'x64' ? '64' : '32';
-    break;
+    platform = 'linux'
+    arch = process.arch === 'x64' ? '64' : '32'
+    break
   default:
-    platform = false;
-    break;
+    platform = false
+    break
 }
 
 var expectedSha = {
@@ -30,60 +29,60 @@ var expectedSha = {
   'linux64': 'c737452bacba963a36d32b3bc0fdb87cb6cb25a6',
   'mac32': '8328d845afb2e5e124f38a2d72dbfc659c0936b0',
   'win32': '7723028c78074144065d07566d77a4c2f19c390a'
-};
+}
 
-var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip';
-var url = 'https://chromedriver.googlecode.com/files/'+ filename;
-var outfile = path.join(path.dirname(__filename), filename);
-var driver = path.join(path.dirname(__filename), 'chromedriver');
+var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip'
+  , url = 'https://chromedriver.googlecode.com/files/'+ filename
+  , outfile = path.join(path.dirname(__filename), filename)
+  , driver = path.join(path.dirname(__filename), 'chromedriver')
 
 module.exports = function(options, cb){
   if( !cb && typeof options === 'function' ){
-    cb = options;
-    options = {};
+    cb = options
+    options = {}
   }
 
   if( !options.chrome ){
-    return cb();
+    return cb()
   }
 
   if( !platform ){
-    return cb('No Chromedriver support for platform: '+ process.platform);
+    return cb('No Chromedriver support for platform: '+ process.platform)
   }
 
   var real = function() {
-    console.log('Downloading Chromedriver '+ version);
-    var i = 0;
+    console.log('Downloading Chromedriver '+ version)
+    var i = 0
     request({ url: url })
       .on('end', function() {
-        process.stdout.write('\n');
+        process.stdout.write('\n')
         process.nextTick(function(){
-          var zip = new Zip(outfile);
-          zip.extractAllTo(path.dirname(__filename));
+          var zip = new Zip(outfile)
+          zip.extractAllTo(path.dirname(__filename))
           fs.chmod(driver, '0111', function(err){
-            if(err) return cb(err);
-            cb(null, driver);
-          });
+            if(err) return cb(err)
+            cb(null, driver)
+          })
         })
       })
       .on('data', function() {
         if (i == 8000) {
-          process.stdout.write('\n');
-          i = 0;
+          process.stdout.write('\n')
+          i = 0
         }
-        if (i % 100 === 0) process.stdout.write('.');
-        i++;
+        if (i % 100 === 0) process.stdout.write('.')
+        i++
       })
-      .pipe(fs.createWriteStream(outfile));
-  };
+      .pipe(fs.createWriteStream(outfile))
+  }
 
   fs.stat(outfile, function(er, stat) {
-    if (er) return real();
+    if (er) return real()
     hashFile(outfile, 'sha1', function(er, actualSha) {
-      if (er) return cb(er);
-      if (actualSha != expectedSha[platform + arch]) return real();
-      cb(null, driver);
-    });
-  });
+      if (er) return cb(er)
+      if (actualSha != expectedSha[platform + arch]) return real()
+      cb(null, driver)
+    })
+  })
 
 };

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 
 var platform
   , arch = '32'
-  , version = '2.6'
+  , version = '2.8'
 
 switch(process.platform){
   case 'darwin':
@@ -25,10 +25,10 @@ switch(process.platform){
 }
 
 var expectedSha = {
-  'linux32': '50fa5c13e7e5a16704c1ea6a5951ddb9198c503b',
-  'linux64': 'cab1c61eea5397498f6a095fcbf726772554fb21',
-  'mac32': '4643652d403961dd9a9a1980eb1a06bf8b6e9bad',
-  'win32': '4196e08c591145fc51828e0a3045f35cb142c51f'
+  'linux32': '8787da5b612fa3d4b3416b95cbdebc4ce2106907',
+  'linux64': '33112f4484145bd0bb8100bac7670d8c45793a4b',
+  'mac32': 'b44d4666d00531f9edc5f1e89534a789fb4ec162',
+  'win32': '2e5ec89661e528bf69f717953896d85896ca64db'
 }
 
 var filename = 'chromedriver_'+ platform + arch +'.zip'

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,9 +9,9 @@ var fs = require('fs')
   , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.42.2'
+  , version = override[0] || '2.44.0'
   , majorMinorVersion = version.split('.').slice(0, 2).join('.')
-  , expectedSha = override[1] || '921005b6628821c9a29de6358917a82d1e3dfa94'
+  , expectedSha = override[1] || 'deb2a8d4f6b5da90fd38d1915459ced2e53eb201'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium-release.storage.googleapis.com/' + majorMinorVersion + '/' + filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
@@ -70,17 +70,25 @@ function run(options, cb) {
     }
     child.host = '127.0.0.1'
     child.port = port
-
-    var badExit = function() { cb(new Error('Could not start Selenium.')) }
-    child.stdout.on('data', function(data) {
-      var sentinal = 'Started org.openqa.jetty.jetty.Server'
-      if (data.toString().indexOf(sentinal) != -1) {
-        child.removeListener('exit', badExit)
-        cb(null, child)
-      }
-    })
-    child.on('exit', badExit)
+    handleData(child, cb);
   })
+}
+
+function handleData(child, cb) {
+  var sentinal = 'Started org.openqa.jetty.jetty.Server'
+  var badExit = function() { cb(new Error('Could not start Selenium.')) }
+  var onData = function(data) {
+    if (data.toString().indexOf(sentinal) !== -1) {
+      child.removeListener('exit', badExit)
+      cb(null, child)
+    }
+  };
+
+  child.stdout.on('data', onData);
+  // For some reason Selenium 2.44.0 writes to stderr instead of stdout?!
+  child.stderr.on('data', onData);
+
+  child.on('exit', badExit)
 }
 
 function FakeProcess(port) {

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,8 +9,8 @@ var fs = require('fs')
   , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.35.0'
-  , expectedSha = override[1] || 'd27ff0f4ff5c06f63ad9113f448f37e6a00147d1'
+  , version = override[0] || '2.39.0'
+  , expectedSha = override[1] || 'f2391600481dd285002d04b66916fc4286ff70ce'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium.googlecode.com/files/' + filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -6,6 +6,7 @@ var fs = require('fs')
   , freeport = require('freeport')
   , EventEmitter = require('events').EventEmitter
   , util = require('util')
+  , chromeDriver = require('./chrome-driver');
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
   , version = override[0] || '2.32.0'
@@ -44,14 +45,24 @@ function download(url, outfile, expectedSha, cb) {
   })
 }
 
-function run(cb) {
+function run(options, cb) {
   freeport(function(er, port) {
     if (er) throw er
     console.log('Starting Selenium ' + version + ' on port ' + port)
-    var child = spawn('java', [
-      '-jar', outfile,
-      '-port', port,
-    ])
+    var child;
+
+    if( options.chrome ){
+      child = spawn('java', [
+        '-jar', outfile,
+        '-Dwebdriver.chrome.driver='+ options.chrome,
+        '-port', port,
+      ])
+    } else {
+      child = spawn('java', [
+        '-jar', outfile,
+        '-port', port,
+      ])
+    }
     child.host = '127.0.0.1'
     child.port = port
 
@@ -77,7 +88,12 @@ FakeProcess.prototype.kill = function() {
   this.emit('exit')
 }
 
-module.exports = function(cb) {
+module.exports = function(options, cb) {
+  if( !cb && typeof options === 'function' ){
+    cb = options;
+    options = { chrome: false };
+  }
+
   if (process.env.SELENIUM_LAUNCHER_PORT) {
     return process.nextTick(
       cb.bind(null, null, new FakeProcess(process.env.SELENIUM_LAUNCHER_PORT)))
@@ -85,6 +101,12 @@ module.exports = function(cb) {
 
   download(url, outfile, expectedSha, function(er) {
     if (er) return cb(er)
-    run(cb)
+    chromeDriver(options, function(err, chromeOutfile){
+      if (er) return cb(er)
+      if( chromeOutfile ){
+        options.chrome = chromeOutfile;
+      }
+      run(options, cb)
+    });
   })
 }

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -13,9 +13,9 @@ var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split
   , expectedSha = override[1] || 'c94e6d5392b687d3a141a35f5a489f50f01bef6a'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium.googlecode.com/files/' + filename
-  , outfile = path.join(path.dirname(__filename), filename)
+  , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
 
-function download(url, outfile, expectedSha, cb) {
+function download(cb) {
   var real = function() {
     console.log('Downloading Selenium ' + version)
     var i = 0
@@ -99,7 +99,7 @@ module.exports = function(options, cb) {
       cb.bind(null, null, new FakeProcess(process.env.SELENIUM_LAUNCHER_PORT)))
   }
 
-  download(url, outfile, expectedSha, function(er) {
+  download(function(er) {
     if (er) return cb(er)
     chromeDriver(options, function(err, chromeOutfile){
       if (er) return cb(er)

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,10 +9,11 @@ var fs = require('fs')
   , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.39.0'
-  , expectedSha = override[1] || 'f2391600481dd285002d04b66916fc4286ff70ce'
+  , version = override[0] || '2.42.2'
+  , majorMinorVersion = version.split('.').slice(0, 2).join('.')
+  , expectedSha = override[1] || '921005b6628821c9a29de6358917a82d1e3dfa94'
   , filename = 'selenium-server-standalone-' + version + '.jar'
-  , url = 'http://selenium.googlecode.com/files/' + filename
+  , url = 'http://selenium-release.storage.googleapis.com/' + majorMinorVersion + '/' + filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
 
 function download(cb) {

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -6,7 +6,7 @@ var fs = require('fs')
   , freeport = require('freeport')
   , EventEmitter = require('events').EventEmitter
   , util = require('util')
-  , chromeDriver = require('./chrome-driver');
+  , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
   , version = override[0] || '2.32.0'
@@ -49,7 +49,7 @@ function run(options, cb) {
   freeport(function(er, port) {
     if (er) throw er
     console.log('Starting Selenium ' + version + ' on port ' + port)
-    var child;
+    var child
 
     if( options.chrome ){
       child = spawn('java', [
@@ -90,8 +90,8 @@ FakeProcess.prototype.kill = function() {
 
 module.exports = function(options, cb) {
   if( !cb && typeof options === 'function' ){
-    cb = options;
-    options = { chrome: false };
+    cb = options
+    options = { chrome: false }
   }
 
   if (process.env.SELENIUM_LAUNCHER_PORT) {
@@ -104,9 +104,9 @@ module.exports = function(options, cb) {
     chromeDriver(options, function(err, chromeOutfile){
       if (er) return cb(er)
       if( chromeOutfile ){
-        options.chrome = chromeOutfile;
+        options.chrome = chromeOutfile
       }
       run(options, cb)
-    });
+    })
   })
 }

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,8 +9,8 @@ var fs = require('fs')
   , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.32.0'
-  , expectedSha = override[1] || 'c94e6d5392b687d3a141a35f5a489f50f01bef6a'
+  , version = override[0] || '2.35.0'
+  , expectedSha = override[1] || 'd27ff0f4ff5c06f63ad9113f448f37e6a00147d1'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium.googlecode.com/files/' + filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-launcher",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/daaku/nodejs-selenium-launcher",
   "author": "Naitik Shah <n@daaku.org>",
   "main": "lib/selenium-launcher",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/daaku/nodejs-selenium-launcher"
   },
   "scripts": {
-    "test": "mocha --timeout 150000 --slow 5000"
+    "test": "make clean && mocha --timeout 150000 --slow 5000"
   },
   "dependencies": {
     "freeport": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-launcher",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/daaku/nodejs-selenium-launcher",
   "author": "Naitik Shah <n@daaku.org>",
   "main": "lib/selenium-launcher",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-launcher",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "homepage": "https://github.com/daaku/nodejs-selenium-launcher",
   "author": "Naitik Shah <n@daaku.org>",
   "main": "lib/selenium-launcher",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,21 @@
     "type": "git",
     "url": "https://github.com/daaku/nodejs-selenium-launcher"
   },
-  "scripts": { "test": "mocha --timeout 150000 --slow 5000" },
+  "scripts": {
+    "test": "mocha --timeout 150000 --slow 5000"
+  },
   "dependencies": {
     "freeport": "1.0.x",
     "request": "2.9.x",
-    "hash_file": "0.0.x"
+    "hash_file": "0.0.x",
+    "adm-zip": "~0.4.3"
   },
   "devDependencies": {
     "mocha": "1.x.x",
-    "soda": "0.2.x"
+    "soda": "0.2.x",
+    "wd": "0.0.34"
   },
-  "engines": { "node": ">= 0.6.x" }
+  "engines": {
+    "node": ">= 0.6.x"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/daaku/nodejs-selenium-launcher"
   },
   "scripts": {
-    "test": "make clean && mocha --timeout 150000 --slow 5000"
+    "test": "make clean && mocha --timeout 240000 --slow 5000"
   },
   "dependencies": {
     "freeport": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "freeport": "1.0.x",
-    "request": "2.9.x",
     "hash_file": "0.0.x",
-    "adm-zip": "~0.4.3"
+    "adm-zip": "~0.4.3",
+    "request": "~2.26.0"
   },
   "devDependencies": {
     "mocha": "1.x.x",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "mocha": "1.x.x",
-    "soda": "0.2.x",
     "wd": "0.0.34"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "mocha": "1.x.x",
-    "wd": "0.0.34"
+    "wd": "0.2.5"
   },
   "engines": {
     "node": ">= 0.6.x"

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ You can override the selenium server version used by the launcer
  via the environment variable
 
 ```bash
-SELENIUM_VERSION=2.32.0:c94e6d5392b687d3a141a35f5a489f50f01bef6a node app.js
+SELENIUM_VERSION=2.39.0:5a8742d5ba1c3d10339541520fead7e7f50712db node app.js
 ```
 
 You'll have to supply a valid sha for the version.

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
   , soda = require('soda')
   , seleniumLauncher = require('../lib/selenium-launcher')
+  , wd = require('wd')
 
 describe("sanity", function(){
 
@@ -26,6 +27,39 @@ describe("sanity", function(){
         selenium.kill()
       })
     })
+  });
+
+  it("should be sane with chrome and stuff", function(done){
+    seleniumLauncher({ chrome: true }, function(er, selenium) {
+      if (er) return done(er)
+      selenium.on('exit', function() { done() })
+
+      var browser = wd.promiseRemote(selenium.host, selenium.port );
+
+      browser.init({ browserName: 'chrome' }, function(err){
+        if( err ) throw new Error(err);
+
+        browser.get('http://google.com')
+          .then(function () {
+            return browser.elementByName('q');
+          })
+          .then(function (el) {
+            searchBox = el;
+            return searchBox.type('webdriver');
+          })
+          .then(function () {
+            return searchBox.getAttribute('value');
+          })
+          .then(function (val) {
+            return assert.equal(val, 'webdriver');
+          })
+          .then(function(){
+            selenium.kill();
+            done();
+          });
+      });
+
+    });
   });
 
 

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -39,7 +39,7 @@ describe("sanity", function(){
     })
   });
 
-  it("should be sane with chrome and stuff", function(done){
+  xit("should be sane with chrome and stuff", function(done){
     seleniumLauncher({ chrome: true }, function(er, selenium) {
       if (er) return done(er)
       selenium.on('exit', function() { done() })

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -34,33 +34,33 @@ describe("sanity", function(){
       if (er) return done(er)
       selenium.on('exit', function() { done() })
 
-      var browser = wd.promiseRemote(selenium.host, selenium.port );
+      var browser = wd.promiseRemote(selenium.host, selenium.port )
 
       browser.init({ browserName: 'chrome' }, function(err){
-        if( err ) throw new Error(err);
+        if( err ) throw new Error(err)
 
         browser.get('http://google.com')
           .then(function () {
-            return browser.elementByName('q');
+            return browser.elementByName('q')
           })
           .then(function (el) {
             searchBox = el;
-            return searchBox.type('webdriver');
+            return searchBox.type('webdriver')
           })
           .then(function () {
-            return searchBox.getAttribute('value');
+            return searchBox.getAttribute('value')
           })
           .then(function (val) {
-            return assert.equal(val, 'webdriver');
+            return assert.equal(val, 'webdriver')
           })
           .then(function(){
-            browser.quit();
-            selenium.kill();
-            done();
-          });
-      });
+            browser.quit()
+            selenium.kill()
+            done()
+          })
+      })
 
-    });
+    })
   });
 
 

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -54,6 +54,7 @@ describe("sanity", function(){
             return assert.equal(val, 'webdriver');
           })
           .then(function(){
+            browser.quit();
             selenium.kill();
             done();
           });


### PR DESCRIPTION
I came across this project while looking to replace some custom code in a grunt task doing similar work with downloading selenium drivers. The one exception is support for the [Selenium Chromedriver](https://code.google.com/p/chromedriver/).

This adds an options object that can be passed to specify that the chrome driver should be downloaded and used while launching selenium. The original API still works and nothing else is downloaded unless you opt in.

I'm looking to use this as a dependency for a [grunt task for running selenium tests with mocha and webdriver locally](https://github.com/wookiehangover/grunt-mocha-selenium), and expand it to support running tests against chrome.
