### PR TITLE
Bump selenium version

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -8,8 +8,8 @@ var fs = require('fs')
   , util = require('util')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.32.0'
-  , expectedSha = override[1] || 'c94e6d5392b687d3a141a35f5a489f50f01bef6a'
+  , version = override[0] || '2.35.0'
+  , expectedSha = override[1] || 'd27ff0f4ff5c06f63ad9113f448f37e6a00147d1'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium.googlecode.com/files/' + filename
   , outfile = path.join(path.dirname(__filename), filename)


### PR DESCRIPTION
The current version of selenium server stopped working in Firefox 23.  Just updating the baked-in version to one that works with the latest browser.
