### PR TITLE
Fixed incorrect SHA for the selenium file download

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,7 +9,7 @@ var fs = require('fs')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
   , version = override[0] || '2.39.0'
-  , expectedSha = override[1] || '5a8742d5ba1c3d10339541520fead7e7f50712db'
+  , expectedSha = override[1] || 'f2391600481dd285002d04b66916fc4286ff70ce'
   , filename = 'selenium-server-standalone-' + version + '.jar'
   , url = 'http://selenium.googlecode.com/files/' + filename
   , outfile = path.join(path.dirname(__filename), filename)


### PR DESCRIPTION
The SHA was incorrect, so the file kept downloading repeatedly. See the SHA here: https://code.google.com/p/selenium/downloads/detail?name=selenium-server-standalone-2.39.0.jar&can=2&q=
