### PR TITLE
Allow use of 'http_proxy' environment variable

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -18,7 +18,11 @@ function download(url, outfile, expectedSha, cb) {
   var real = function() {
     console.log('Downloading Selenium ' + version)
     var i = 0
-    request({ url: url })
+    var requestOptions = {url: url};
+    if (process.env.http_proxy != null) {
+      requestOptions.proxy = process.env.http_proxy;
+    }
+    request(requestOptions)
       .on('end', function() {
         process.stdout.write('\n')
         cb()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-launcher",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "homepage": "https://github.com/daaku/nodejs-selenium-launcher",
   "author": "Naitik Shah <n@daaku.org>",
   "main": "lib/selenium-launcher",


### PR DESCRIPTION
Added check for `http_proxy` environment variable, and if present, use proxy
- This check maintains the original default behaviour, resulting in no changes unless the environment variable `http_proxy` is set
  - If set, the request module's existing proxy functionality is used to proxy the request

Bumped version to `1.1.10` (No API changes, or breaking functionality)
