### PR TITLE
Make verbosity setable

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -48,10 +48,14 @@ function download(url, outfile, expectedSha, cb) {
   })
 }
 
-function run(cb) {
+function run(cb, opts) {
+
   freeport(function(er, port) {
     if (er) throw er
-    console.log('Starting Selenium ' + version + ' on port ' + port)
+    if (opts.verbose) {
+        console.log('Starting Selenium ' + version + ' on port ' + port)
+    }
+
     var child = spawn('java', [
       '-jar', outfile,
       '-port', port,
@@ -81,7 +85,18 @@ FakeProcess.prototype.kill = function() {
   this.emit('exit')
 }
 
-module.exports = function(cb) {
+function SetDefaultOptions (opts) {
+    if (!('verbose' in opts)) opts.verbose = true
+    return opts
+}
+
+module.exports = function(opts, cb) {
+  if (typeof cb == 'undefined' || typeof opts != 'object') {
+      cb = opts
+      opts = {}
+  }
+  opts = SetDefaultOptions(opts)
+
   if (process.env.SELENIUM_LAUNCHER_PORT) {
     return process.nextTick(
       cb.bind(null, null, new FakeProcess(process.env.SELENIUM_LAUNCHER_PORT)))
@@ -89,6 +104,6 @@ module.exports = function(cb) {
 
   download(url, outfile, expectedSha, function(er) {
     if (er) return cb(er)
-    run(cb)
+    run(cb, opts)
   })
 }


### PR DESCRIPTION
I didn't appreciate the "Starting Selenium ..." line being printed every time, so I added an optional options object that can be passed. This might also be a good starting point for https://github.com/daaku/nodejs-selenium-launcher/issues/7, where the port can be easily specified as an option.
