### PR TITLE
Provide a way to customise the port Selenium starts on

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -52,9 +52,8 @@ function download(url, outfile, expectedSha, cb) {
   })
 }
 
-function run(cb) {
-  freeport(function(er, port) {
-    if (er) throw er;
+function run(cb, port) {
+  function runOnPort(cb, port) {
     console.log('Starting Selenium ' + version + ' on port ' + port);
     console.log('Filename: ' + outfile);
     var child = spawn('java', [
@@ -73,7 +72,16 @@ function run(cb) {
       }
     })
     child.on('exit', badExit)
-  })
+  }
+
+  if (typeof port === 'undefined') {
+    freeport(function (er, port) {
+      if (er) throw er;
+      runOnPort(cb, port)
+    })
+  } else {
+    runOnPort(cb, port)
+  }
 }
 
 function FakeProcess(port) {
@@ -86,7 +94,7 @@ FakeProcess.prototype.kill = function() {
   this.emit('exit');
 }
 
-module.exports = function(cb) {
+module.exports = function(cb, port) {
   if (process.env.SELENIUM_LAUNCHER_PORT) {
     return process.nextTick(
       cb.bind(null, null, new FakeProcess(process.env.SELENIUM_LAUNCHER_PORT)))
@@ -94,6 +102,6 @@ module.exports = function(cb) {
 
   download(url, outfile, expectedSha, function(er) {
     if (er) return cb(er)
-    run(cb)
+    run(cb, port)
   })
 }

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -40,4 +40,13 @@ describe("sanity", function(){
     })
   });
 
+  it('should get the server port from the optional parameter', function(done) {
+    seleniumLauncher(function(er, selenium) {
+      if (er) return done(er);
+      assert.equal(selenium.port, 4444);
+      selenium.on('exit', function() { done() })
+      selenium.kill()
+    }, 4444)
+  });
+
 });


### PR DESCRIPTION
Allow passing the port on which Selenium should start as an optional parameter to seleniumLauncher.

This is useful for using seleniumLauncher as an aid to running [intern](http://theintern.io/) tests, as intern only allows setting its webdriver port in a config file (and not on the command line).

Fixes #7
